### PR TITLE
Init default FolderName when resolving untyped options

### DIFF
--- a/src/Proffer.Storage/Configuration/ConfigurationExtensions.cs
+++ b/src/Proffer.Storage/Configuration/ConfigurationExtensions.cs
@@ -125,6 +125,11 @@ namespace Proffer.Storage.Configuration
             where TStoreOptions : class, IStoreOptions, new()
             where TScopedStoreOptions : class, TStoreOptions, IScopedStoreOptions
         {
+            if (string.IsNullOrEmpty(parsedStore.FolderName))
+            {
+                parsedStore.FolderName = parsedStore.Name;
+            }
+
             TInstanceOptions instanceOptions = null;
             if (!string.IsNullOrEmpty(parsedStore.ProviderName))
             {

--- a/src/Proffer.Storage/Configuration/ConfigurationExtensions.cs
+++ b/src/Proffer.Storage/Configuration/ConfigurationExtensions.cs
@@ -125,11 +125,6 @@ namespace Proffer.Storage.Configuration
             where TStoreOptions : class, IStoreOptions, new()
             where TScopedStoreOptions : class, TStoreOptions, IScopedStoreOptions
         {
-            if (string.IsNullOrEmpty(parsedStore.FolderName))
-            {
-                parsedStore.FolderName = parsedStore.Name;
-            }
-
             TInstanceOptions instanceOptions = null;
             if (!string.IsNullOrEmpty(parsedStore.ProviderName))
             {
@@ -185,6 +180,11 @@ namespace Proffer.Storage.Configuration
             {
                 Name = kvp.Key,
             };
+
+            if (options is IStoreOptions storeOptions && string.IsNullOrEmpty(storeOptions.FolderName))
+            {
+                storeOptions.FolderName = options.Name;
+            }
 
             ConfigurationBinder.Bind(kvp.Value, options);
             return options;

--- a/src/Proffer.Storage/Configuration/StorageOptions.cs
+++ b/src/Proffer.Storage/Configuration/StorageOptions.cs
@@ -66,7 +66,7 @@ namespace Proffer.Storage.Configuration
         /// <summary>
         /// Gets or sets the parsed stores options.
         /// </summary>
-        public IReadOnlyDictionary<string, StoreOptions> ParsedStores { get => FillFolderNameWithStoreNameIfItIsNull(this.parsedStores.Value); set { } }
+        public IReadOnlyDictionary<string, StoreOptions> ParsedStores { get => this.parsedStores.Value; set { } }
 
         /// <summary>
         /// Gets or sets the parsed scoped stores options.
@@ -85,22 +85,5 @@ namespace Proffer.Storage.Configuration
         /// <param name="storeOptions">The store options.</param>
         /// <param name="providerInstanceOptions">The provider instance options.</param>
         public void BindStoreOptions(StoreOptions storeOptions, ProviderOptions providerInstanceOptions) { }
-
-        /// <summary>
-        /// If folder name is null filling it with store name
-        /// </summary>
-        /// <param name="parsedStores">The parsed stores.</param>
-        private IReadOnlyDictionary<string, StoreOptions> FillFolderNameWithStoreNameIfItIsNull(IReadOnlyDictionary<string, StoreOptions> parsedStores)
-        {
-            foreach (var parsedStore in parsedStores)
-            {
-                if (string.IsNullOrEmpty(parsedStore.Value.FolderName))
-                {
-                    parsedStore.Value.FolderName = parsedStore.Value.Name;
-                }
-            }
-
-            return parsedStores;
-        }
     }
 }

--- a/src/Proffer.Storage/Configuration/StorageOptions.cs
+++ b/src/Proffer.Storage/Configuration/StorageOptions.cs
@@ -66,7 +66,7 @@ namespace Proffer.Storage.Configuration
         /// <summary>
         /// Gets or sets the parsed stores options.
         /// </summary>
-        public IReadOnlyDictionary<string, StoreOptions> ParsedStores { get => this.parsedStores.Value; set { } }
+        public IReadOnlyDictionary<string, StoreOptions> ParsedStores { get => FillFolderNameWithStoreNameIfItIsNull(this.parsedStores.Value); set { } }
 
         /// <summary>
         /// Gets or sets the parsed scoped stores options.
@@ -85,5 +85,22 @@ namespace Proffer.Storage.Configuration
         /// <param name="storeOptions">The store options.</param>
         /// <param name="providerInstanceOptions">The provider instance options.</param>
         public void BindStoreOptions(StoreOptions storeOptions, ProviderOptions providerInstanceOptions) { }
+
+        /// <summary>
+        /// If folder name is null filling it with store name
+        /// </summary>
+        /// <param name="parsedStores">The parsed stores.</param>
+        private IReadOnlyDictionary<string, StoreOptions> FillFolderNameWithStoreNameIfItIsNull(IReadOnlyDictionary<string, StoreOptions> parsedStores)
+        {
+            foreach (var parsedStore in parsedStores)
+            {
+                if (string.IsNullOrEmpty(parsedStore.Value.FolderName))
+                {
+                    parsedStore.Value.FolderName = parsedStore.Value.Name;
+                }
+            }
+
+            return parsedStores;
+        }
     }
 }

--- a/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
+++ b/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
@@ -17,20 +17,20 @@ namespace Proffer.Storage.Tests
     [Feature(nameof(Configuration))]
     public class StorageConfigurationTests
     {
-        //[Fact(Skip = "Logged issue")]
-        //[Bug("https://github.com/asiffermann/proffer/issues/47")]
-        //public void Should_ValidateStoreOptions_Without_Errors()
-        //{
-        //    var fixture = new SimpleServiceProviderFixture(
-        //        (sp, f) => sp.AddStorage(f.Configuration).AddStubStorage());
+        [Fact]
+        [Bug("https://github.com/asiffermann/proffer/issues/47")]
+        public void Should_ValidateStoreOptions_Without_Errors()
+        {
+            var fixture = new SimpleServiceProviderFixture(
+                (sp, f) => sp.AddStorage(f.Configuration).AddStubStorage());
 
-        //    IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
+            IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
 
-        //    IEnumerable<IOptionError> errors = options.Value.ParsedStores
-        //        .SelectMany(s => s.Value.Validate(throwOnError: false));
+            IEnumerable<IOptionError> errors = options.Value.ParsedStores
+                .SelectMany(s => s.Value.Validate(throwOnError: false));
 
-        //    Assert.Empty(errors);
-        //}
+            Assert.Empty(errors);
+        }
 
         [Fact]
         public void Should_ValidateStubStoreOptions_Without_Errors()

--- a/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
+++ b/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
@@ -93,28 +93,28 @@ namespace Proffer.Storage.Tests
             Assert.NotNull(missingProviderError);
         }
 
-        [Fact]
-        [Bug("https://github.com/asiffermann/proffer/issues/47")]
-        public void Should_ValidateStoreOptions_With_MissingFolderName()
-        {
-            string sectionName = "BadStorage";
-            string storeName = "ConfiguredStore";
+        //[Fact(Skip = "Logged issue")]
+        //[Bug("https://github.com/asiffermann/proffer/issues/47")]
+        //public void Should_ValidateStoreOptions_With_MissingFolderName()
+        //{
+        //    string sectionName = "BadStorage";
+        //    string storeName = "ConfiguredStore";
 
-            var fixture = new SimpleServiceProviderFixture(
-                (sp, f) => sp.AddStorage(f.Configuration.GetSection(sectionName)).AddStubStorage(),
-                new()
-                {
-                    { $"{sectionName}:Stores:{storeName}:Name", storeName },
-                    { $"{sectionName}:Stores:{storeName}:ProviderType", "Stub" },
-                });
+        //    var fixture = new SimpleServiceProviderFixture(
+        //        (sp, f) => sp.AddStorage(f.Configuration.GetSection(sectionName)).AddStubStorage(),
+        //        new()
+        //        {
+        //            { $"{sectionName}:Stores:{storeName}:Name", storeName },
+        //            { $"{sectionName}:Stores:{storeName}:ProviderType", "Stub" },
+        //        });
 
-            IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
-            StoreOptions storeOptions = options.Value.ParsedStores[storeName];
+        //    IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
+        //    StoreOptions storeOptions = options.Value.ParsedStores[storeName];
 
-            IEnumerable<IOptionError> errors = storeOptions.Validate(throwOnError: false);
+        //    IEnumerable<IOptionError> errors = storeOptions.Validate(throwOnError: false);
 
-            Assert.Empty(errors);
-        }
+        //    Assert.Empty(errors);
+        //}
 
         [Fact]
         public void Should_ValidateStubStoreOptions_With_MissingFolderName()

--- a/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
+++ b/tests/Proffer.Storage.Tests/StorageConfigurationTests.cs
@@ -93,28 +93,28 @@ namespace Proffer.Storage.Tests
             Assert.NotNull(missingProviderError);
         }
 
-        //[Fact(Skip = "Logged issue")]
-        //[Bug("https://github.com/asiffermann/proffer/issues/47")]
-        //public void Should_ValidateStoreOptions_With_MissingFolderName()
-        //{
-        //    string sectionName = "BadStorage";
-        //    string storeName = "ConfiguredStore";
+        [Fact]
+        [Bug("https://github.com/asiffermann/proffer/issues/47")]
+        public void Should_ValidateStoreOptions_With_MissingFolderName()
+        {
+            string sectionName = "BadStorage";
+            string storeName = "ConfiguredStore";
 
-        //    var fixture = new SimpleServiceProviderFixture(
-        //        (sp, f) => sp.AddStorage(f.Configuration.GetSection(sectionName)).AddStubStorage(),
-        //        new()
-        //        {
-        //            { $"{sectionName}:Stores:{storeName}:Name", storeName },
-        //            { $"{sectionName}:Stores:{storeName}:ProviderType", "Stub" },
-        //        });
+            var fixture = new SimpleServiceProviderFixture(
+                (sp, f) => sp.AddStorage(f.Configuration.GetSection(sectionName)).AddStubStorage(),
+                new()
+                {
+                    { $"{sectionName}:Stores:{storeName}:Name", storeName },
+                    { $"{sectionName}:Stores:{storeName}:ProviderType", "Stub" },
+                });
 
-        //    IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
-        //    StoreOptions storeOptions = options.Value.ParsedStores[storeName];
+            IOptions<StorageOptions> options = fixture.Services.GetRequiredService<IOptions<StorageOptions>>();
+            StoreOptions storeOptions = options.Value.ParsedStores[storeName];
 
-        //    IEnumerable<IOptionError> errors = storeOptions.Validate(throwOnError: false);
+            IEnumerable<IOptionError> errors = storeOptions.Validate(throwOnError: false);
 
-        //    Assert.Empty(errors);
-        //}
+            Assert.Empty(errors);
+        }
 
         [Fact]
         public void Should_ValidateStubStoreOptions_With_MissingFolderName()


### PR DESCRIPTION
I tried understand why Should_ValidateStubStoreOptions_With_MissingFolderName works success and this one is not. Then i realised in the ConfigurationExtensions class you are assigning the name property to foldername property if it is null. So i wrote a function inside the StorageOptions's class inside with the same logic.